### PR TITLE
Fix loaderScript bug in phantomjs

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -16,7 +16,7 @@
     loaderScript = scripts[scripts.length - 1]
   }
 
-  var loaderSrc = util.getScriptAbsoluteSrc(loaderScript) ||
+  var loaderSrc = (loaderScript && util.getScriptAbsoluteSrc(loaderScript)) ||
       util.pageUri // When sea.js is inline, set base to pageUri.
 
   var base = util.dirname(getLoaderActualSrc(loaderSrc))
@@ -32,7 +32,7 @@
   config.base = base
 
 
-  var dataMain = loaderScript.getAttribute('data-main')
+  var dataMain = loaderScript && loaderScript.getAttribute('data-main')
   if (dataMain) {
     config.main = dataMain
   }


### PR DESCRIPTION
当使用 phantom.injectJs 插入 seajs 时。由于当前页面没有 script 标签，导致脚本运行出错。修改后，使用https://gist.github.com/3607735 的代码运行没有问题。
