### PR TITLE
处理1.3.0-dev版本中的URL路径切分BUG

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -24,7 +24,7 @@
 
   // When src is "http://test.com/libs/seajs/1.0.0/sea.js", redirect base
   // to "http://test.com/libs/"
-  var match = base.match(/^(.+\/)seajs\/[\d\.]+\/$/)
+  var match = base.match(/^(.+\/)seajs\/[\.\-\w]+\/$/)
   if (match) base = match[1]
 
   config.base = base


### PR DESCRIPTION
由于 1.3.0-dev 版本路径中引入了非数字的部分 (dev) ,  原有的URL路径切分正则已不适用, 为了正确把"assets/sea-modules/seajs/1.3.0-dev/sea-debug.js"路径中的  1.3.0-dev 部分识别出来， 需要修改切分正则.   
