### PR TITLE
解决代码注释影响依赖解析的问题

### DIFF
--- a/src/util-deps.js
+++ b/src/util-deps.js
@@ -8,15 +8,12 @@
 
     code
       .replace(/(['"])((:?\\\1|.)+?)\1/g, function(match, quote, str, index) {  // extract all strings
-        _strings.push(str);
-        return '"' + (_strings.length - 1) + '"';
+        return '"' + (_strings.push(str) - 1) + '"';
       })
       .replace(/\/\*[\s\S]*?\*\//mg, '') // remove block comments
       .replace(/\/\/.*$/mg, '') // remove line comments
       .replace(/(?:^|[^.$])\brequire\s*\(\s*"(\d+)"\s*\)/g, function(match, index) {  // parse 'require()'
-        if (index && _strings[index]) {
-          ret.push(_strings[index]);
-        }
+        ret.push(_strings[index]);
       });
 
     return util.unique(ret);


### PR DESCRIPTION
用到了我在[Issue #478](https://github.com/seajs/seajs/issues/478#issuecomment-11476690)中提到的思路：
1. 匹配出所有字符串（也就是`''`或者`""`包裹的东西），把它们替换成唯一的字符串，在一个数组中储存这个唯一字符串和原字符串的对应关系
2. 用正则移除注释（`//`之后的或`/*`与`*/`之间的内容）
3. 找出`requre`，用中间的字符串（也就是第1步被我替换掉的）在第1步的数组中找到原始的字符串
