### PR TITLE
Update plugin-combo.js

### DIFF
--- a/src/plugins/plugin-combo.js
+++ b/src/plugins/plugin-combo.js
@@ -194,28 +194,42 @@
   //
   function paths2hash(paths) {
     var comboSyntax = configData.comboSyntax || ["??", ","]
-
+    
     forEach(paths, function(path) {
       var root = path[0] + "/"
       var group = files2group(path[1])
 
       forEach(group, function(files) {
-        var comboPath = root + comboSyntax[0] + files.join(comboSyntax[1])
-
-        // http://stackoverflow.com/questions/417142/what-is-the-maximum-length-of-a-url
-        if (comboPath.length > 2000) {
-          throw new Error("The combo url is too long: " + comboPath)
-        }
-
-        forEach(files, function(part) {
-          comboHash[root + part] = comboPath
-        })
+        parseComboHash(root, files, comboSyntax)
       })
 
     })
 
     return comboHash
   }
+  
+  function parseComboHash(root, files, comboSyntax){
+    var comboPath = root + comboSyntax[0] + files.join(comboSyntax[1])
+    
+    // http://stackoverflow.com/questions/417142/what-is-the-maximum-length-of-a-url
+    if (comboPath.length > 2000) {
+      var halfFiles = halfArray(files)
+      
+      parseComboHash(root, halfFiles[0], comboSyntax)
+      parseComboHash(root, halfFiles[1], comboSyntax)
+      //throw new Error("The combo url is too long: " + comboPath)
+    } else {
+      forEach(files, function(part) {
+        comboHash[root + part] = comboPath
+      })
+    }
+  }
+  
+  var halfArray = function(arr){
+    var cloneArr = arr.concat();
+		
+		return [cloneArr.splice(0, Math.ceil(arr.length/2)), cloneArr];
+	}
 
   //
   //  ["a.js", "c/d.js", "c/e.js", "a.css", "b.css", "z"]


### PR DESCRIPTION
combo后的url长度超过2000后不是直接抛错误，而是用对半拆分的方式拆成多个url，场景更加通用

P.S. 可以在 debug 模式下抛出错误
