### PR TITLE
去掉文档 script 属性配置中多出的一个 尖括号

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -168,7 +168,7 @@ examples/
       在 <code>hello.html</code> 里，与脚本相关的代码只有一行：
     </p>
 <pre class="sh_html">
-&lt;script&gt;
+&lt;script
     src="static/seajs/sea.js"   -- sea.js 路径
     data-config="hello/config"  -- 给 SeaJS 用的项目配置文件
     data-main="hello/main"&gt;     -- 项目的起始模块


### PR DESCRIPTION
昨天得知发布了新版，迫不及待就更新开始使用，先温习了一遍文档。直接拷贝这段进行修改：

```
<script>
    src="static/seajs/sea.js"   -- sea.js 路径
    data-config="hello/config"  -- 给 SeaJS 用的项目配置文件
    data-main="hello/main">     -- 项目的起始模块
</script>
```

发现出错，检查一下，原来这里多了一个 `>`,就顺手到 `docs/index.html` 中修复一下，即：

```
&lt;script
    src="static/seajs/sea.js"   -- sea.js 路径
    data-config="hello/config"  -- 给 SeaJS 用的项目配置文件
    data-main="hello/main"&gt;     -- 项目的起始模块
&lt;/script&gt;
```
