### PR TITLE
修复Shim插件在未指定src时不工作的问题

### DIFF
--- a/src/plugins/plugin-shim.js
+++ b/src/plugins/plugin-shim.js
@@ -39,6 +39,16 @@
                     exports
           })
 
+        } else {
+
+          // Define the proxy cmd module use an exist object when src file have been loaded before
+          define(id, item.deps, function() {
+            var exports = item.exports
+            return typeof exports === "function" ? exports() :
+                typeof exports === "string" ? global[exports] :
+                    exports
+          })
+
         }
       })(alias[id])
     }


### PR DESCRIPTION
当设置alias时，如不设置src，只设置exports，且相关代码在seajs脚本前已经加。预期应该定义exports指定的对象的cmd代理模块，但实际上没指定src则没有任何操作。

``` javascript
  alias: {
    'jquery': {
      exports: 'jQuery'
    }
  }
```

以上设置没有预期的jquery module.

只有设置以下时才工作正常。

``` javascript
  alias: {
    'jquery': {
      src: 'path/to/jquery.js',
      exports: 'jQuery'
    }
  }
```
