### PR TITLE
完善测试用例失败时的信息提示

### DIFF
--- a/tests/page-runner.js
+++ b/tests/page-runner.js
@@ -70,9 +70,9 @@
   global.testNextPage = function() {
     if (page) {
       publish('testEnd', page, {
-        pass: result.pass.count,
-        fail: result.fail.count,
-        error: result.error.count
+        pass: result.pass,
+        fail: result.fail,
+        error: result.error
       })
     }
 
@@ -92,7 +92,7 @@
       // Load page
       var url = getUrl(page)
       printHeader(page, url, 'h2')
-      
+
       publish('test', page)
       load(url)
       makeSureGoOn(page)


### PR DESCRIPTION
比如在 util 这个模块中的 events.js 中发生错误时，会有下面的 events.js, charset, 等具体信息的定位。

```
passed 10 of 16 tests in 13885ms
    specs/util - specs/util - events.js
    specs/config - specs/config - charset
    specs/module - specs/module - anywhere
    specs/package - specs/package - math
    specs/extensible - specs/extensible - combo-map
    specs/extensible/plugin-debug - specs/extensible/plugin-debug - specs/extensible/plugin-debug
```
