### PR TITLE
Fix tools/size.sh

### DIFF
--- a/tools/size.sh
+++ b/tools/size.sh
@@ -9,8 +9,8 @@ SIZE_MIN=$(cat dist/$MIN | wc -c)
 SIZE_GZIP=$(gzip -c1 dist/$MIN | wc -c)
 
 echo
-echo -e "\t`echo "scale=3;$SIZE_SRC/1024" | bc -l` KB $SRC"
-echo -e "\t`echo "scale=3;$SIZE_MIN/1024" | bc -l` KB $MIN"
-echo -e "\t`echo "scale=3;$SIZE_GZIP/1024" | bc -l` KB $MIN gzipped"
-echo -e "\t`cat dist/$1-debug.js | wc -l` LOC"
+echo -e "\t$(echo "scale=3;$SIZE_SRC/1024" | bc -l) KB $SRC"
+echo -e "\t$(echo "scale=3;$SIZE_MIN/1024" | bc -l) KB $MIN"
+echo -e "\t$(echo "scale=3;$SIZE_GZIP/1024" | bc -l) KB $MIN gzipped"
+echo -e "\t$(cat dist/$1-debug.js | wc -l) LOC"
 echo


### PR DESCRIPTION
Add -e to enable backslash escapes.

`$()` is prefected over ```` and unified to other code.
