### PR TITLE
more humanization for Module.use

### DIFF
--- a/src/module.js
+++ b/src/module.js
@@ -341,7 +341,7 @@ Module.use = function (ids, callback, uri) {
 
     for (var i = 0, len = uris.length; i < len; i++) {
       var temp = cachedMods[uris[i]].exec()
-      if (!temp) {
+      if (temp) {
         exports.push(temp)
       }
     }


### PR DESCRIPTION
见代码：

``` javascript
seajs.use(['jquery', 'my cmd module'], function (r1, mod) {
   console.log(r1)  //undefined
   console.log(mod)  // get my module exports correctly
})
```

其实我想这样

``` javascript
seajs.use(['jquery', 'my cmd module'], function (mod) {
   console.log(mod)  // get my module exports correctly
})
```
