### PR TITLE
compatible amd

### DIFF
--- a/src/module.js
+++ b/src/module.js
@@ -382,7 +382,7 @@ seajs.use = function(ids, callback) {
   return seajs
 }
 
-Module.define.cmd = {}
+Module.define.cmd = Module.define.amd = {}
 global.define = Module.define
 
 


### PR DESCRIPTION
some library like jQuery has

```
if ( typeof define === "function" && define.amd ) {
    define( "jquery", [], function () { return jQuery; } );
}
```

after this, can directly load by seajs without wrap
