### PR TITLE
解决 realpath 无法正确处理包含 '././' 的路径问题

### DIFF
--- a/src/util-path.js
+++ b/src/util-path.js
@@ -4,7 +4,7 @@
 
 var DIRNAME_RE = /[^?#]*\//
 
-var DOT_RE = /\/\.\//g
+var DOT_RE = /\/\.\//
 var DOUBLE_DOT_RE = /\/[^/]+\/\.\.\//
 var DOUBLE_SLASH_RE = /([^:/])\/\//g
 
@@ -19,7 +19,9 @@ function dirname(path) {
 // realpath("http://test.com/a//./b/../c") ==> "http://test.com/a/c"
 function realpath(path) {
   // /a/b/./c/./d ==> /a/b/c/d
-  path = path.replace(DOT_RE, "/")
+  while (path.match(DOT_RE)) {
+    path = path.replace(DOT_RE, "/")
+  }
 
   // a/b/c/../../d  ==>  a/b/../d  ==>  a/d
   while (path.match(DOUBLE_DOT_RE)) {


### PR DESCRIPTION
原来的函数处理 /a/b/././c 会得到 /a/b/./c 而不是 /a/b/c
