### PR TITLE
child module under debug mode add parent dependents

### DIFF
--- a/src/module.js
+++ b/src/module.js
@@ -72,6 +72,14 @@ Module.prototype.load = function() {
   for (var i = 0; i < len; i++) {
     m = Module.get(uris[i])
 
+    if(data.debug) {
+
+      // parent dependent
+      isArray(m.parents) ?
+        m.parents.push(mod) :
+        (m.parents = [mod])
+    }
+
     if (m.status < STATUS.LOADED) {
       // Maybe duplicate: When module has dupliate dependency, it should be it's count, not 1
       m._waitings[mod.uri] = (m._waitings[mod.uri] || 0) + 1


### PR DESCRIPTION
在`seajsV1.3.1` 中在`require('xxxx')` 模块的时候，会在`xxx`module上添加模块父级模块依赖https://github.com/seajs/seajs/blob/1.3.1/src/module.js#L137
对于前端模块构建集成后，针对模块加载不成功，可以根据`seajs.cache`对象找到模块失败的父级依赖，并较好解决问题的效果，所以在`seajsv2.x` 版本中保留此功能
