### PR TITLE
Update module.js

### DIFF
--- a/src/module.js
+++ b/src/module.js
@@ -225,6 +225,8 @@ Module.prototype.exec = function () {
     Module.use(ids, callback, uri + "_async_" + cid())
     return require
   }
+  
+  require.get = require;
 
   // Exec factory
   var factory = mod.factory


### PR DESCRIPTION
add require.get method

我在实际工作中，在一个项目里公开了多个模块，其中一些是有明显的顺序的：譬如，先加载了main.js，后加载login.js，然后才加载game.js
但是因为我希望他们是分开loading的，所以在spm build的时候，我选择让他们也分开输出main.js和login.js还有game.js三个文件。
此时如果他们都依赖了一个公共的utils.js，spm build的结果中，三个文件都会包含utils.js的源代码。所以我希望我能手动控制此事。

最初我选择了用这样的一个hack：
var utils = require(require.resolve("./utils"));

这是可以工作的，但是略麻烦，所以我希望在require中增加一个方法（参见我的commit）：

var utils = require.get("./utils");

这两种做法都能够让utils.js不再被包含（在main.js里，我依然用require("./utils")来使得build后的结果包含utils.js）。

最终的修改很简洁，而且这应该是没有害处的，可能有一些人和我遇到相同的需求，所以提交此pull request。
