### PR TITLE
Update: realpath method in util-path.js

### DIFF
--- a/src/util-path.js
+++ b/src/util-path.js
@@ -6,7 +6,7 @@ var DIRNAME_RE = /[^?#]*\//
 
 var DOT_RE = /\/\.\//g
 var DOUBLE_DOT_RE = /\/[^/]+\/\.\.\//
-var DOUBLE_SLASH_RE = /([^:/])\/\//g
+var MULTI_SLASH_RE = /([^:/])\/+\//g
 
 // Extract the directory portion of a path
 // dirname("a/b/c.js?t=123#xx/zz") ==> "a/b/"
@@ -21,13 +21,13 @@ function realpath(path) {
   // /a/b/./c/./d ==> /a/b/c/d
   path = path.replace(DOT_RE, "/")
 
-  // Modified by @wh1100717
-  // DOUBLE_DOT_RE matches a/b/c//../d path correctly only if replace // with / first
-  // a//b/c  ==>  a/b/c
-  // a///b/c ==> a//b/c ==> a/b/c
-  while (path.match(DOUBLE_SLASH_RE)) {
-    path = path.replace(DOUBLE_SLASH_RE, "$1/")
-  }
+  /*
+    @author wh1100717
+    a//b/c ==> a/b/c
+    a///b/////c ==> a/b/c
+    DOUBLE_DOT_RE matches a/b/c//../d path correctly only if replace // with / first
+  */
+  path = path.replace(MULTI_SLASH_RE, "$1/")
 
   // a/b/c/../../d  ==>  a/b/../d  ==>  a/d
   while (path.match(DOUBLE_DOT_RE)) {


### PR DESCRIPTION
1. DOUBLE_DOT_RE will match `a/b/c//../d` path correctly only if `//` is replaced with `/` first
2.  `a///b/c` should be parsed into `a/b/c`.
