### PR TITLE
Fix the dead link for 'How To Ask Questions The Smart Way'

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -230,7 +230,7 @@ GitHub 的 Markdown 语法可以很好地支持代码排版、语法高亮等，
 ## 延伸阅读
 
 - [如何有效地报告 Bug](http://www.chiark.greenend.org.uk/~sgtatham/bugs-cn.html)
-- [提问的智慧](http://www.wapm.cn/smart-questions/smart-questions-zh.html)
+- [提问的智慧](http://www.beiww.com/doc/oss/smart-questions.html)
 - [回答的智慧](http://code.google.com/p/cpyug/wiki/ZenForAsk)
 
 ---


### PR DESCRIPTION
原来的链接貌似已经失效，我想从原版英文的网站找到中文翻译版本，但也是这个。[新的链接](http://www.beiww.com/doc/oss/smart-questions.html)是从提问的智慧的中文[wiki](https://zh.wikipedia.org/wiki/%E6%8F%90%E9%97%AE%E7%9A%84%E6%99%BA%E6%85%A7)上找到的，不知是否可以。
