### PR TITLE
Shorten the readyState checking RegExp

### DIFF
--- a/src/util-request.js
+++ b/src/util-request.js
@@ -64,7 +64,7 @@ else {
     }
     else {
       node.onreadystatechange = function() {
-        if (/loaded|complete/.test(node.readyState)) {
+        if (/de|co/.test(node.readyState)) {
           onload()
         }
       }


### PR DESCRIPTION
I have tested the performance. There is almost no difference.

IE8 Result:

|           |  <code>/loaded&#124;complete/</code> | <code>/^c&#124;loaded/</code> | <code>/de&#124;co/</code> |
| ------- | ------------------------: | ---------------: | ---------: |
| 10 AVG(ms)   |                      821.2 |           889.1 |    847.3 |

Test script is below:

```js
var readystates = [
    'uninitialized',
    'loading',
    'loaded',
    'interactive',
    'complete'
];

// #1
var times = 50000;
var start1 = +new Date;
for (var i = 0; i < times; i++) {
    for (var j = 0; j < readystates.length; j++) {
        /complete|loaded/.test(readystates[i]);
    }
}
var diff1 = new Date - start1;

// #2
var start2 = +new Date;
for (var i = 0; i < times; i++) {
    for (var j = 0; j < readystates.length; j++) {
        /^co|loaded/.test(readystates[i]);
    }
}
var diff2 = new Date - start2;

// #3
var start3 = +new Date;
for (var i = 0; i < times; i++) {
    for (var j = 0; j < readystates.length; j++) {
        /de|co/.test(readystates[i]);
    }
}
var diff3 = new Date - start3;

alert(diff1 + ', ' + diff2 + ', ' + diff3);
```