### PR TITLE
docs: Fix simple typo, themeselves -> themselves

### DIFF
--- a/tests/specs/util/events.js
+++ b/tests/specs/util/events.js
@@ -82,7 +82,7 @@ define(function(require) {
   assert(obj.counter === 1, obj.counter)
 
 
-  // two binds that unbind themeselves
+  // two binds that unbind themselves
   obj.off()
   obj.counterA = 0
   obj.counterB = 0


### PR DESCRIPTION
There is a small typo in tests/specs/util/events.js.

Closes #1749

